### PR TITLE
Fix segfault in solid_color() when filling blank walls

### DIFF
--- a/setroot.c
+++ b/setroot.c
@@ -483,6 +483,7 @@ void parse_opts( unsigned int argc, char **args )
         if (mn >= nwalls) { // fill remaining monitors with blank walls
             init_wall(&(WALLS[mn]));
             WALLS[mn].option = COLOR;
+            WALLS[mn].bgcol = parse_color("black");
         }
         MONS[mn].wall = &(WALLS[mn]);
     }


### PR DESCRIPTION
This is only a "quick fix" that fixes the crash. One might think about adding a new command line argument to specify the color of blank monitors -- or something among these lines.
