### PR TITLE
Fix --use-{x,y}-geometry

### DIFF
--- a/setroot.c
+++ b/setroot.c
@@ -453,8 +453,10 @@ void parse_opts( unsigned int argc, char **args )
     /* set up monitors based on arrangement option */
     if        (streq(args[argc - 1], "--use-x-geometry")) {
         sort_mons_by(SORT_BY_XORG);
+        argc--;
     } else if (streq(args[argc - 1], "--use-y-geometry")) {
         sort_mons_by(SORT_BY_YORG);
+        argc--;
     } else {
         sort_mons_by(SORT_BY_XINM);
     }


### PR DESCRIPTION
Esentially, we have to mark that last argument as "consumed". Otherwise,
setroot would try to read it as an image file.