### PR TITLE
Add Installation Instructions for Arch and Nix

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -30,7 +30,22 @@ ego died many ages ago in undergrad.
 
 INSTALLATION
 ------------
+Arch
+~~~~
+Install https://aur.archlinux.org/packages/setroot/[setroot] or https://aur.archlinux.org/packages/setroot-git/[setroot-git] from the AUR.
 
+Nix
+~~~
+Setroot can also be installed using https://nixos.org/nix/[nix], which is a distro-independent package manager.
+
+----
+nix-env -i setroot
+----
+
+Overriding `enableXinerama` to false will install setroot without xinerama support.
+
+Manual
+~~~~~~
 If you have `libxinerama` installed:
 
 ----


### PR DESCRIPTION
After packaging setroot for nix, I have a couple of suggestions. I noticed that trying to use `--on` when setroot was compiled without xinerama support would give an error message like `Image -on not found.` It might be nice to have an error message mentioning that setroot was not compiled with support for `--on`.

Also, due to differences in setroot's Makefile from most Makefiles, I had to modify the defaults for the install phase in the package. Usually PREFIX is "/usr/local" instead of "usr/local", and there is no "/" in between the DESTDIR and BINDIR. This actually causes there to be a "//" in the path when building with nix (which doesn't cause a problem, but I thought that I'd point it out).