### PR TITLE
Minor improvement to warning message

### DIFF
--- a/setroot.c
+++ b/setroot.c
@@ -207,8 +207,8 @@ Window find_desktop( Window window )
 		if (n_chldrn) XFree(chldrn);
 
     } else {
-		fprintf(stderr, "Cannot find window that sets wallpaper. \
-						 Defaulting to root window. \n");
+		fprintf(stderr, "Cannot find window that sets wallpaper. "
+						"Defaulting to root window.\n");
     } return desktop_window;
 }
 


### PR DESCRIPTION
I think this is what you really want. You can concatenate string literals in C just like that. :-)

In the original version, the string contained all the tabs and spaces that were meant to be *indentation*. So, the message on the terminal read like:

    Cannot find window that sets wallpaper.                      Defaulting to root window.
