### PR TITLE
Add an error check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ man/setroot.1.txt
 arch/
 arch/**
 arch/**/**
+setroot

--- a/setroot.c
+++ b/setroot.c
@@ -1052,6 +1052,9 @@ parse_opts( unsigned int argc, char **args )
 
         if (!streq(image_path, "__COLOR__")) {
             Imlib_Image image = imlib_load_image(image_path);
+
+            if (image == NULL) invalid_img_error(image_path);
+
             imlib_context_set_image(image);
 
             w->image  = image;


### PR DESCRIPTION
After loading an image, `imlib_image_get_width()` will complain if the image is NULL.

This pull request adds a check.